### PR TITLE
Use tagged-literal as default reader for edn input

### DIFF
--- a/src/cq/formats.clj
+++ b/src/cq/formats.clj
@@ -34,7 +34,7 @@
 (defn ->edn-reader
   [_]
   (fn [in]
-    (edn/read (PushbackReader. (io/reader in)))))
+    (edn/read {:default tagged-literal} (PushbackReader. (io/reader in)))))
 
 (defn ->edn-writer
   [{:keys [pretty color]}]


### PR DESCRIPTION
# What

Allow cq to read custom reader macros from edn input.

# Why

cq fails when reading custom reader macros, and demands an extra step from the user to use sed or some other tool to clear such macros.

# How

Add `{:default tagged-literal}` when reading edn input